### PR TITLE
(issue#59)user registration layout

### DIFF
--- a/little-guy-creator-app/App.js
+++ b/little-guy-creator-app/App.js
@@ -9,6 +9,7 @@ import HomeScreen from './components/homeScreen.js';
 import CreateScreen from './components/createScreen.js';
 import EditScreen from './components/editScreen.js';
 import LoginScreen from './components/loginScreen.js';
+import RegistrationScreen from "./components/registrationScreen.js";
 
 // All the screens listed here for the navigator
 // **** be sure to add new pages here!
@@ -25,7 +26,8 @@ const RootStack = createNativeStackNavigator({
         },
         Edit: EditScreen,
         Create: CreateScreen,
-        'Sign In': LoginScreen
+        'Sign In': LoginScreen,
+        Registration: RegistrationScreen,
     },
 });
 

--- a/little-guy-creator-app/components/feedbackTextInput.js
+++ b/little-guy-creator-app/components/feedbackTextInput.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { View, Text, Image, TextInput } from 'react-native';
+import { createStaticNavigation, useNavigation } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Button } from '@react-navigation/elements';
+import {styles} from '../styles.js';
+
+// Text input field with feedback text (e.g. for following constraints)
+const FeedbackTextInput = (props) => {
+    return (
+        <View>
+            <Text>{props.title}:</Text>
+                <TextInput
+                    style={styles.input}
+                    onChangeText={props.onChangeText}
+                    editable={props.editable}
+                    placeholder={props.placeholder}
+                    secureTextEntry={props.secureTextEntry}
+                />
+            <Text>{props.feedback}</Text>
+        </View>
+    );
+}
+
+export default FeedbackTextInput

--- a/little-guy-creator-app/components/feedbackTextInput.js
+++ b/little-guy-creator-app/components/feedbackTextInput.js
@@ -17,7 +17,7 @@ const FeedbackTextInput = (props) => {
                     placeholder={props.placeholder}
                     secureTextEntry={props.secureTextEntry}
                 />
-            <Text>{props.feedback}</Text>
+            <Text style={styles.errorText}>{props.feedback}</Text>
         </View>
     );
 }

--- a/little-guy-creator-app/components/loginScreen.js
+++ b/little-guy-creator-app/components/loginScreen.js
@@ -4,6 +4,7 @@ import { createStaticNavigation, useNavigation } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Button } from '@react-navigation/elements';
 import {styles} from '../styles.js';
+import FeedbackTextInput from './feedbackTextInput.js';
 
 // Error messages
 const ALERT_FIELD_BLANK = "This field is required.";
@@ -15,23 +16,6 @@ const ValidationResult = {
     OK: 0,
     INVALID: 1,
     ERROR: 2,
-}
-
-// Field Layout component for Username or Password
-const InputField = (props) => {
-    return (
-        <View>
-            <Text>{props.title}:</Text>
-                <TextInput
-                    style={styles.input}
-                    onChangeText={props.onChangeText}
-                    editable={props.editable}
-                    placeholder={props.placeholder}
-                    secureTextEntry={props.secureTextEntry}
-                />
-            <Text>{props.alert}</Text>
-        </View>
-    );
 }
 
 const LoginScreen = (props) => {
@@ -91,6 +75,10 @@ const LoginScreen = (props) => {
 
     }
 
+    const onCreateNewAccount = () => {
+        navigation.navigate('Registration');
+    }
+
     return (
       <View style={styles.container}>
         <Text style={styles.h1}>Sign In</Text>
@@ -98,32 +86,34 @@ const LoginScreen = (props) => {
         <View style={{pad: 20, width: "90%" }}>
 
             {/* Username Field */}
-            <InputField
+            <FeedbackTextInput
                 title="Username"
                 onChangeText={onUsernameChanged}
                 editable={!awaitingValidation}
-                alert={isUsernameBlank ? ALERT_FIELD_BLANK : null}
+                feedback={isUsernameBlank ? ALERT_FIELD_BLANK : null}
             />
 
             {/* Small Spacer */}
             <View style={ {margin: 10} } />
 
             {/* Password Field */}
-            <InputField
+            <FeedbackTextInput
                 title="Password"
                 onChangeText={onPasswordChanged}
                 editable={!awaitingValidation}
-                alert={isPasswordBlank ? ALERT_FIELD_BLANK : null}
+                feedback={isPasswordBlank ? ALERT_FIELD_BLANK : null}
                 secureTextEntry={true}
             />
 
             {/* Small Spacer */}
             <View style={ {margin: 10} } />
 
+            {/* Sign In Button */}
             <Button onPress={onSignInPress} title="Sign-In" disabled={awaitingValidation}>
                 {awaitingValidation ? "Signing In..." : "Sign In"}
             </Button>
             {
+                // Error/invalid message on signing in
                 validationResult === ValidationResult.INVALID ?
                     <Text style={styles.tcenter}>{ALERT_INVALID}</Text> :
                     validationResult === ValidationResult.ERROR ?
@@ -133,6 +123,8 @@ const LoginScreen = (props) => {
 
             {/* Divider */}
             <View style={styles.div}/>
+
+            <Button onPress={onCreateNewAccount}>Create an account</Button>
 
         </View>
 

--- a/little-guy-creator-app/components/registrationScreen.js
+++ b/little-guy-creator-app/components/registrationScreen.js
@@ -6,16 +6,81 @@ import { Button } from '@react-navigation/elements';
 import {styles} from '../styles.js';
 import FeedbackTextInput from './feedbackTextInput.js';
 
-// Error messages
+// Error messages (frontend alerts)
 const ALERT_FIELD_BLANK = "This field is required.";
-const ALERT_USERNAME_DUPLICATE = "This username is already taken.";
 const ALERT_PASSWORD_MISMATCH = "Passwords do not match."
 const ALERT_PASSWORD_LENGTH = "Passwords must be 10 or more characters.";
 
+// Error messages (backend alerts)
+const ALERT_USERNAME_DUPLICATE = "This username is already taken.";
 const ALERT_ERROR = "Something went wrong. Please try again.";
+
+
+const getFieldBlank = (field) => {
+    return field === ""
+}
+
+const getPasswordsMatch = (password, confirmPassword) => {
+    return password === confirmPassword;
+}
+
+const getPasswordLongEnough = (password) => {
+    return password.length >= 10;
+}
+
 
 const RegistrationScreen = (props) => {
 
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+
+    const [usernameFeedback, setUsernameFeedback] = useState("");
+    const [passwordFeedback, setPasswordFeedback] = useState("");
+    const [confirmPasswordFeedback, setConfirmPasswordFeedback] = useState("");
+
+    const [awaitingValidation, setAwaitingValidation] = useState(false);
+
+    const onUsernameChanged = (text) => {
+        setUsername(text);
+
+        if (getFieldBlank(text)) {
+            setUsernameFeedback(ALERT_FIELD_BLANK);
+        } else {
+            setUsernameFeedback("");
+        }
+    }
+
+    const onPasswordChanged = (text) => {
+        setPassword(text);
+
+        if (getFieldBlank(text)) {
+            setPasswordFeedback(ALERT_FIELD_BLANK);
+        } else if (!getPasswordLongEnough(text)) {
+            setPasswordFeedback(ALERT_PASSWORD_LENGTH);
+        } else {
+            setPasswordFeedback("");
+        }
+
+        // Also update confirm password feedback
+        getPasswordsMatch(text, confirmPassword) ?
+            setConfirmPasswordFeedback("") :
+            setConfirmPasswordFeedback(ALERT_PASSWORD_MISMATCH);
+    }
+
+    const onConfirmPasswordChanged = (text) => {
+        setConfirmPassword(text);
+
+        if (!getPasswordsMatch(password, text)) {
+            setConfirmPasswordFeedback(ALERT_PASSWORD_MISMATCH);
+        } else {
+            setConfirmPasswordFeedback("");
+        }
+    }
+
+    const onSubmitButtonPressed = () => {
+
+    }
 
     return (
       <View style={styles.container}>
@@ -26,20 +91,31 @@ const RegistrationScreen = (props) => {
 
             <FeedbackTextInput
                 title="Username"
+                onChangeText={onUsernameChanged}
+                editable={!awaitingValidation}
+                feedback={usernameFeedback}
             />
 
             <FeedbackTextInput
                 title="Password"
+                secureTextEntry={true}
+                onChangeText={onPasswordChanged}
+                editable={!awaitingValidation}
+                feedback={passwordFeedback}
             />
 
             <FeedbackTextInput
                 title="Confirm Password"
+                secureTextEntry={true}
+                onChangeText={onConfirmPasswordChanged}
+                editable={!awaitingValidation}
+                feedback={confirmPasswordFeedback}
             />
 
             {/* Small Spacer */}
             <View style={ {margin: 10} } />
 
-            <Button>Submit</Button>
+            <Button onPress={onSubmitButtonPressed}>Submit</Button>
 
         </View>
 

--- a/little-guy-creator-app/components/registrationScreen.js
+++ b/little-guy-creator-app/components/registrationScreen.js
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { View, Text, Image, TextInput } from 'react-native';
+import { createStaticNavigation, useNavigation } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Button } from '@react-navigation/elements';
+import {styles} from '../styles.js';
+import FeedbackTextInput from './feedbackTextInput.js';
+
+// Error messages
+const ALERT_FIELD_BLANK = "This field is required.";
+const ALERT_USERNAME_DUPLICATE = "This username is already taken.";
+const ALERT_PASSWORD_MISMATCH = "Passwords do not match."
+const ALERT_PASSWORD_LENGTH = "Passwords must be 10 or more characters.";
+
+const ALERT_ERROR = "Something went wrong. Please try again.";
+
+const RegistrationScreen = (props) => {
+
+
+    return (
+      <View style={styles.container}>
+
+        <Text style={styles.h1}>Create an account</Text>
+
+        <View style={{pad: 20, width: "90%" }}>
+
+            <FeedbackTextInput
+                title="Username"
+            />
+
+            <FeedbackTextInput
+                title="Password"
+            />
+
+            <FeedbackTextInput
+                title="Confirm Password"
+            />
+
+            {/* Small Spacer */}
+            <View style={ {margin: 10} } />
+
+            <Button>Submit</Button>
+
+        </View>
+
+      </View>
+    );
+}
+
+export default RegistrationScreen;

--- a/little-guy-creator-app/styles.js
+++ b/little-guy-creator-app/styles.js
@@ -86,4 +86,8 @@ export const styles = StyleSheet.create({
     padding: 10,
   },
 
+  errorText: {
+    color: 'firebrick'
+  },
+
 });


### PR DESCRIPTION
Closes #59 
Implements a user registration screen layout, with frontend constraints
Accessible through the sign in page
Currently does not make API calls and will always report "username already taken"